### PR TITLE
Allows requesting of 'When in Use' when compiling with the iOS 7 SDK but run on iOS 8.

### DIFF
--- a/Source/INTULocationManager.m
+++ b/Source/INTULocationManager.m
@@ -475,16 +475,13 @@ static id _sharedInstance;
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
 {
-    if (status == kCLAuthorizationStatusDenied || status == kCLAuthorizationStatusRestricted) {
+    if (status == kCLAuthorizationStatusNotDetermined) {
+        // Intentially do nothing since we have not yet determined what we can/should do
+    } else if (status == kCLAuthorizationStatusDenied || status == kCLAuthorizationStatusRestricted) {
         // Clear out any pending location requests (which will execute the blocks with a status that reflects
         // the unavailability of location services) since we now no longer have location services permissions
         [self completeAllLocationRequests];
-    }
-#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1
-    else if (status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorizedWhenInUse) {
-#else
-    else if (status == kCLAuthorizationStatusAuthorized) {
-#endif /* __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1 */
+    } else {
         // Start the timeout timer for location requests that were waiting for authorization
         for (INTULocationRequest *locationRequest in self.locationRequests) {
             [locationRequest startTimeoutTimerIfNeeded];


### PR DESCRIPTION
You may find this change useful, especially during the transition from iOS 7 -> 8.

If your app isn't compiled with the 8.0 SDK, but runs on iOS 8, it will default to requesting for "always authorization." That is expected behavior, but kind of sucks for the developer if you just wanted to request for "when in use".

This change makes it so if the `locationManager` has the new APIs, it will use them, but if not, it will continue to behave as a regular pre-iOS 8 app would.

Considering all this, it may be a good idea to also remove that `NSAssert` if neither key is found in the Info.plist file. Since it is possible an iOS 7 app was built without these keys, and it would just start crashing on iOS 8 without much warning. I'll let y'all make the call on that one, though. Just let me know if you'd like it removed.
