### PR TITLE
Removed unnecessary break's  in switch statements

### DIFF
--- a/Source/INTULocationRequest.m
+++ b/Source/INTULocationRequest.m
@@ -82,23 +82,17 @@ static NSInteger _nextRequestID = 0;
     switch (self.desiredAccuracy) {
         case INTULocationAccuracyRoom:
             return kINTUUpdateTimeStaleThresholdRoom;
-            break;
         case INTULocationAccuracyHouse:
             return kINTUUpdateTimeStaleThresholdHouse;
-            break;
         case INTULocationAccuracyBlock:
             return kINTUUpdateTimeStaleThresholdBlock;
-            break;
         case INTULocationAccuracyNeighborhood:
             return kINTUUpdateTimeStaleThresholdNeighborhood;
-            break;
         case INTULocationAccuracyCity:
             return kINTUUpdateTimeStaleThresholdCity;
-            break;
         default:
             NSAssert(NO, @"Unknown desired accuracy.");
             return 0.0;
-            break;
     }
 }
 
@@ -110,23 +104,17 @@ static NSInteger _nextRequestID = 0;
     switch (self.desiredAccuracy) {
         case INTULocationAccuracyRoom:
             return kINTUHorizontalAccuracyThresholdRoom;
-            break;
         case INTULocationAccuracyHouse:
             return kINTUHorizontalAccuracyThresholdHouse;
-            break;
         case INTULocationAccuracyBlock:
             return kINTUHorizontalAccuracyThresholdBlock;
-            break;
         case INTULocationAccuracyNeighborhood:
             return kINTUHorizontalAccuracyThresholdNeighborhood;
-            break;
         case INTULocationAccuracyCity:
             return kINTUHorizontalAccuracyThresholdCity;
-            break;
         default:
             NSAssert(NO, @"Unknown desired accuracy.");
             return 0.0;
-            break;
     }
 }
 


### PR DESCRIPTION
Removed unnecessary break's  in switch statements. Code was never reached since there is a pre return statement.
