### PR TITLE
Updated statusForLocation permissions management

### DIFF
--- a/INTULocationManager.podspec
+++ b/INTULocationManager.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name                  = "INTULocationManager"
-  s.version               = "2.0.3"
+  s.version               = "2.0.4"
   s.homepage              = "https://github.com/intuit/LocationManager"
   s.license               = { :type => 'MIT', :file => 'LICENSE' }
   s.author                = { "Tyler Fox" => "tyler_fox@intuit.com" }
-  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.3" }
+  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.4" }
   s.source_files          = 'Source'
   s.platform              = :ios
   s.ios.deployment_target = '6.0'

--- a/Source/INTULocationManager.m
+++ b/Source/INTULocationManager.m
@@ -428,7 +428,10 @@ static id _sharedInstance;
  */
 - (INTULocationStatus)statusForLocationRequest:(INTULocationRequest *)locationRequest
 {
-    if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined) {
+    if ([CLLocationManager locationServicesEnabled] == NO) {
+        return INTULocationStatusServicesDisabled;
+    }
+    else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined) {
         return INTULocationStatusServicesNotDetermined;
     }
     else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied) {
@@ -436,9 +439,6 @@ static id _sharedInstance;
     }
     else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted) {
         return INTULocationStatusServicesRestricted;
-    }
-    else if ([CLLocationManager locationServicesEnabled] == NO) {
-        return INTULocationStatusServicesDisabled;
     }
     else if (self.updateFailed) {
         return INTULocationStatusError;


### PR DESCRIPTION
I don't know if that was related to an iOS update, but in the case the location services were disabled on the phone, the method `statusForLocation` would always return `INTULocationStatusServicesDenied`. I just moved the check `if ([CLLocationManager locationServicesEnabled] == NO)` at first to fix it.

