### PR TITLE
Distinguish between location services disabled in the settings and location services in the application

### DIFF
--- a/INTULocationManager.podspec
+++ b/INTULocationManager.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name                  = "INTULocationManager"
-  s.version               = "2.0.4"
+  s.version               = "2.0.5"
   s.homepage              = "https://github.com/intuit/LocationManager"
   s.license               = { :type => 'MIT', :file => 'LICENSE' }
   s.author                = { "Tyler Fox" => "tyler_fox@intuit.com" }
-  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.4" }
+  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.5" }
   s.source_files          = 'Source'
   s.platform              = :ios
   s.ios.deployment_target = '6.0'

--- a/INTULocationManager.podspec
+++ b/INTULocationManager.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name                  = "INTULocationManager"
-  s.version               = "2.0.3"
+  s.version               = "2.0.4"
   s.homepage              = "https://github.com/intuit/LocationManager"
   s.license               = { :type => 'MIT', :file => 'LICENSE' }
   s.author                = { "Tyler Fox" => "tyler_fox@intuit.com" }
-  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.3" }
+  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.4" }
   s.source_files          = 'Source'
   s.platform              = :ios
   s.ios.deployment_target = '6.0'

--- a/INTULocationManager.podspec
+++ b/INTULocationManager.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name                  = "INTULocationManager"
-  s.version               = "2.0.5"
+  s.version               = "2.0.4"
   s.homepage              = "https://github.com/intuit/LocationManager"
   s.license               = { :type => 'MIT', :file => 'LICENSE' }
   s.author                = { "Tyler Fox" => "tyler_fox@intuit.com" }
-  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.5" }
+  s.source                = { :git => "https://github.com/intuit/LocationManager.git", :tag => "v2.0.4" }
   s.source_files          = 'Source'
   s.platform              = :ios
   s.ios.deployment_target = '6.0'

--- a/Source/INTULocationManager.h
+++ b/Source/INTULocationManager.h
@@ -38,6 +38,19 @@
 + (instancetype)sharedInstance;
 
 /**
+ Returns YES if location services are enabled in the system settings.
+ Returns NO otherwise.
+ */
+-(BOOL) locationServicesEnabled;
+
+/**
+ Returns YES if location services for the specific application you are working on are enabled in the system settings.
+ Returns NO otherwise.
+ Note that this method will return YES even if the authorization status has not yet been determined.
+ */
+-(BOOL) applicationLocationAuthorizationEnabled;
+
+/**
  Asynchronously requests the current location of the device using location services.
  
  @param desiredAccuracy The accuracy level desired (refers to the accuracy and recency of the location).

--- a/Source/INTULocationManager.m
+++ b/Source/INTULocationManager.m
@@ -100,19 +100,10 @@ static id _sharedInstance;
     return YES;
 }
 
-/**
- Returns YES if location services are enabled in the system settings.
-    Returns NO otherwise.
- */
 - (BOOL) locationServicesEnabled {
     return [CLLocationManager locationServicesEnabled];
 }
 
-/**
- Returns YES if location services for the specific application you are working on are enabled in the system settings.
-    Returns NO otherwise.
- Note that this method will return YES even if the authorization status has not yet been determined.
- */
 -(BOOL) applicationLocationAuthorizationEnabled {
     if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied) {
         return NO;

--- a/Source/INTULocationManager.m
+++ b/Source/INTULocationManager.m
@@ -92,9 +92,29 @@ static id _sharedInstance;
  */
 - (BOOL)locationServicesAvailable
 {
-    if ([CLLocationManager locationServicesEnabled] == NO) {
+    if (![self locationServicesEnabled]) {
         return NO;
-    } else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied) {
+    } else if (![self applicationLocationAuthorizationEnabled]) {
+        return NO;
+    }
+    return YES;
+}
+
+/**
+ Returns YES if location services are enabled in the system settings.
+    Returns NO otherwise.
+ */
+- (BOOL) locationServicesEnabled {
+    return [CLLocationManager locationServicesEnabled];
+}
+
+/**
+ Returns YES if location services for the specific application you are working on are enabled in the system settings.
+    Returns NO otherwise.
+ Note that this method will return YES even if the authorization status has not yet been determined.
+ */
+-(BOOL) applicationLocationAuthorizationEnabled {
+    if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied) {
         return NO;
     } else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted) {
         return NO;

--- a/Source/INTULocationManager.m
+++ b/Source/INTULocationManager.m
@@ -428,7 +428,10 @@ static id _sharedInstance;
  */
 - (INTULocationStatus)statusForLocationRequest:(INTULocationRequest *)locationRequest
 {
-    if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined) {
+    if ([CLLocationManager locationServicesEnabled] == NO) {
+        return INTULocationStatusServicesDisabled;
+    }
+    else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined) {
         return INTULocationStatusServicesNotDetermined;
     }
     else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied) {
@@ -436,9 +439,6 @@ static id _sharedInstance;
     }
     else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted) {
         return INTULocationStatusServicesRestricted;
-    }
-    else if ([CLLocationManager locationServicesEnabled] == NO) {
-        return INTULocationStatusServicesDisabled;
     }
     else if (self.updateFailed) {
         return INTULocationStatusError;

--- a/Source/INTULocationManager.m
+++ b/Source/INTULocationManager.m
@@ -92,29 +92,9 @@ static id _sharedInstance;
  */
 - (BOOL)locationServicesAvailable
 {
-    if (![self locationServicesEnabled]) {
+    if ([CLLocationManager locationServicesEnabled] == NO) {
         return NO;
-    } else if (![self applicationLocationAuthorizationEnabled]) {
-        return NO;
-    }
-    return YES;
-}
-
-/**
- Returns YES if location services are enabled in the system settings.
-    Returns NO otherwise.
- */
-- (BOOL) locationServicesEnabled {
-    return [CLLocationManager locationServicesEnabled];
-}
-
-/**
- Returns YES if location services for the specific application you are working on are enabled in the system settings.
-    Returns NO otherwise.
- Note that this method will return YES even if the authorization status has not yet been determined.
- */
--(BOOL) applicationLocationAuthorizationEnabled {
-    if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied) {
+    } else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied) {
         return NO;
     } else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted) {
         return NO;


### PR DESCRIPTION
Created two methods `locationServicesEnabled` and `applicationLocationAuthorizationEnabled` to distinguish between when the user has location services disabled in general for their device and when they've authorized the application to use location services.