### PR TITLE
Added support to specify which location authorization is used.

### DIFF
--- a/Source/INTULocationManager.h
+++ b/Source/INTULocationManager.h
@@ -71,6 +71,29 @@
                                                       block:(INTULocationRequestBlock)block;
 
 /**
+ Asynchronously requests the current location of the device using location services, optionally delaying the timeout countdown until the user has
+ responded to the dialog requesting permission for this app to access location services.
+ 
+ @param desiredAccuracy             The accuracy level desired (refers to the accuracy and recency of the location).
+ @param timeout                     The maximum amount of time (in seconds) to wait for a location with the desired accuracy before completing. If
+                                    this value is 0.0, no timeout will be set (will wait indefinitely for success, unless request is force completed or canceled).
+ @param delayUntilAuthorized        A flag specifying whether the timeout should only take effect after the user responds to the system prompt 
+                                    requesting permission for this app to access location services. If YES, the timeout countdown will not begin until 
+                                    after the app receives location services permissions. If NO, the timeout countdown begins immediately when calling
+                                    this method.
+ @param usageAuthorizationChoice    Usage choice to use when requesting location authorization. INTULocationUsageAuthorizationChoiceDefault should be 
+                                    used if you are unsure. Only used when on iOS 8.
+ @param block                       The block to execute upon success, failure, or timeout.
+ 
+ @return The location request ID, which can be used to force early completion or cancel the request while it is in progress.
+ */
+- (INTULocationRequestID)requestLocationWithDesiredAccuracy:(INTULocationAccuracy)desiredAccuracy
+                                                    timeout:(NSTimeInterval)timeout
+                                       delayUntilAuthorized:(BOOL)delayUntilAuthorized
+                                   usageAuthorizationChoice:(INTULocationUsageAuthorizationChoice)choice
+                                                      block:(INTULocationRequestBlock)block;
+
+/**
  Creates a subscription for location updates that will execute the block once per update indefinitely (until canceled), regardless of the accuracy of each location.
  If an error occurs, the block will execute with a status other than INTULocationStatusSuccess, and the subscription will be canceled automatically.
  

--- a/Source/INTULocationRequestDefines.h
+++ b/Source/INTULocationRequestDefines.h
@@ -56,6 +56,16 @@ typedef NS_ENUM(NSInteger, INTULocationServicesState) {
     INTULocationServicesStateDisabled
 };
 
+/* Location usage authorization choices */
+typedef NS_ENUM(NSInteger, INTULocationUsageAuthorizationChoice) {
+    /** INTULocationManager should use requestAlwaysAuthorization for authorization. */
+    INTULocationUsageAuthorizationChoiceAlways,
+    /** INTULocationManager should use requestWhenInUseAuthorization for authorization. */
+    INTULocationUsageAuthorizationChoiceWhenInUse,
+    /** INTULocationManager can pick either depending on the keys in Info.plist. (Default behavior) */
+    INTULocationUsageAuthorizationChoiceDefault
+};
+
 /** A unique ID that corresponds to one location request. */
 typedef NSInteger INTULocationRequestID;
 


### PR DESCRIPTION
Added support to specify which location authorization is used.

This can be useful if you app have both NSLocationAlwaysUsageDescription and NSLocationWhenInUseUsageDescription defined, but you want to use a particular one for INTULocationManager.

