### PR TITLE
Adds distanceFilter setting

### DIFF
--- a/LocationManager/INTULocationManager/INTULocationManager.h
+++ b/LocationManager/INTULocationManager/INTULocationManager.h
@@ -47,6 +47,13 @@ __INTU_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 
 /**
+ * Specifies the minimum amount of change in meters needed for a location service update. Observers will not be notified of updates less than the stated filter value.
+ *
+ * @discussion The default value for this is kCLDistanceFilterNone.
+ */
+@property (nonatomic) INTULocationFilterAccuracy distanceFilter;
+
+/**
  Asynchronously requests the current location of the device using location services.
  
  @param desiredAccuracy The accuracy level desired (refers to the accuracy and recency of the location).

--- a/LocationManager/INTULocationManager/INTULocationManager.m
+++ b/LocationManager/INTULocationManager/INTULocationManager.m
@@ -287,6 +287,17 @@ static id _sharedInstance;
     }
 }
 
+/**
+ * Specifies the minimum amount of change in meters needed for a location service update. Observers will not be notified of updates less than the stated filter value.
+ */
+- (void)setDistanceFilter:(INTULocationFilterAccuracy)distanceFilter
+{
+    _distanceFilter = distanceFilter;
+
+    // Note: This updates the distance filter for all requests
+    self.locationManager.distanceFilter = distanceFilter;
+}
+
 #pragma mark Internal methods
 
 /**

--- a/LocationManager/INTULocationManager/INTULocationRequestDefines.h
+++ b/LocationManager/INTULocationManager/INTULocationRequestDefines.h
@@ -101,6 +101,10 @@ typedef NS_ENUM(NSInteger, INTULocationAccuracy) {
     INTULocationAccuracyRoom,
 };
 
+/** An alias of the distance filter accuracy in meters.
+ Specifies the minimum amount of change in meters needed for a location service update. Observers will not be notified of updates less than the stated filter value. Default value is kCLDistanceFilterNone */
+typedef CLLocationDistance INTULocationFilterAccuracy;
+
 /** A status that will be passed in to the completion block of a location request. */
 typedef NS_ENUM(NSInteger, INTULocationStatus) {
     // These statuses will accompany a valid location.


### PR DESCRIPTION
Currently subscriptions get constant updates because `locationManager:didUpdateLocations:` gets called every second. Exposing the `distanceFilter` setting allows you to specify that we should only be notified after a minimum amount of change in meters.

This also helps with battery life (and potentially network hits if you're sending the location data anywhere).