### PR TITLE
Added two new setter for properties of the CLLocationManager object

### DIFF
--- a/LocationManager/INTULocationManager/INTULocationManager.h
+++ b/LocationManager/INTULocationManager/INTULocationManager.h
@@ -166,6 +166,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setShowsBackgroundLocationIndicator:(BOOL) shows;
 
+/**
+ Sets a Boolean value indicating whether the location manager object may pause location updates.
+ 
+ @param shows           Boolean value indicating whether the location manager object may pause location updates.
+ */
+- (void)setPausesLocationUpdatesAutomatically:(BOOL) pauses;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/LocationManager/INTULocationManager/INTULocationManager.h
+++ b/LocationManager/INTULocationManager/INTULocationManager.h
@@ -150,6 +150,22 @@ NS_ASSUME_NONNULL_BEGIN
 /** It is possible to force enable background location fetch even if your set any kind of Authorizations */
 - (void)setBackgroundLocationUpdate:(BOOL) enabled;
 
+/**
+ Sets a Boolean indicating whether the status bar changes its appearance when location services
+ are used in the background.
+ 
+ This property affects only apps that received always authorization. When such an app moves to the background,
+ the system uses this property to determine whether to change the status bar appearance to indicate that
+ location services are in use. Displaying a modified status bar gives the user a quick way to return to your app.
+ The default value of this property is false.
+ 
+ For apps with when-in-use authorization, the system always changes the status bar appearance when
+ the app uses location services in the background.
+ 
+ @param shows           Boolean indicating whether the status bar changes its appearance when location services are used in the background.
+ */
+- (void)setShowsBackgroundLocationIndicator:(BOOL) shows;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/LocationManager/INTULocationManager/INTULocationManager.m
+++ b/LocationManager/INTULocationManager/INTULocationManager.m
@@ -1017,4 +1017,9 @@ BOOL INTUCLHeadingIsIsValid(CLHeading *heading)
         _locationManager.showsBackgroundLocationIndicator = shows;
     }
 }
+    
+- (void)setPausesLocationUpdatesAutomatically:(BOOL) pauses
+{
+    _locationManager.pausesLocationUpdatesAutomatically = pauses
+}
 @end

--- a/LocationManager/INTULocationManager/INTULocationManager.m
+++ b/LocationManager/INTULocationManager/INTULocationManager.m
@@ -1007,7 +1007,9 @@ BOOL INTUCLHeadingIsIsValid(CLHeading *heading)
 #pragma mark - Additions
 /** It is possible to force enable background location fetch even if your set any kind of Authorizations */
 - (void)setBackgroundLocationUpdate:(BOOL) enabled {
-    _locationManager.allowsBackgroundLocationUpdates = enabled;
+    if (@available(iOS 9, *)) {
+        _locationManager.allowsBackgroundLocationUpdates = enabled;
+    }
 }
 
 - (void)setShowsBackgroundLocationIndicator:(BOOL) shows {

--- a/LocationManager/INTULocationManager/INTULocationManager.m
+++ b/LocationManager/INTULocationManager/INTULocationManager.m
@@ -1010,4 +1010,7 @@ BOOL INTUCLHeadingIsIsValid(CLHeading *heading)
     _locationManager.allowsBackgroundLocationUpdates = enabled;
 }
 
+- (void)setShowsBackgroundLocationIndicator:(BOOL) shows {
+    _locationManager.showsBackgroundLocationIndicator = shows;
+}
 @end

--- a/LocationManager/INTULocationManager/INTULocationManager.m
+++ b/LocationManager/INTULocationManager/INTULocationManager.m
@@ -1020,6 +1020,6 @@ BOOL INTUCLHeadingIsIsValid(CLHeading *heading)
     
 - (void)setPausesLocationUpdatesAutomatically:(BOOL) pauses
 {
-    _locationManager.pausesLocationUpdatesAutomatically = pauses
+    _locationManager.pausesLocationUpdatesAutomatically = pauses;
 }
 @end

--- a/LocationManager/INTULocationManager/INTULocationManager.m
+++ b/LocationManager/INTULocationManager/INTULocationManager.m
@@ -1011,6 +1011,8 @@ BOOL INTUCLHeadingIsIsValid(CLHeading *heading)
 }
 
 - (void)setShowsBackgroundLocationIndicator:(BOOL) shows {
-    _locationManager.showsBackgroundLocationIndicator = shows;
+    if (@available(iOS 11, *)) {
+        _locationManager.showsBackgroundLocationIndicator = shows;
+    }
 }
 @end


### PR DESCRIPTION
Hey,
I added two new methods to access the `showBackgroundIndicator` and the `pausesLocationUpdatesAutomatically` properties of the internal CLLocationManager object.

The first is new to iOS 11 and handy, to give the user an indication that your app is currently using the location updates in the background and the second is quite handy to tell the CLLocationManger, to never stop requesting, even if the user has a pause for coffee or so (fixes issue #70).

I would also suggest du bump the version of this pod soon since the latest fix of the usage descriptions for using the always authentication for the location services is critical in my opinion, otherwise apps build for iOS 11 aren't able to get an always authentication.

Thanks for this great pod!

Cheers,
Daniel