### PR TITLE
adding logo to be used by the OS Site

### DIFF
--- a/os-project-logo.svg
+++ b/os-project-logo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 40.7 40.7" style="enable-background:new 0 0 40.7 40.7;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#0071CE;}
+</style>
+<path class="st0" d="M5.6,12.8v14h30v-14H5.6z M9.6,23.7H8.5v-7.8h1.1V23.7z M17.7,23.7h-1.2l-3.9-6.3v6.3h-1v-7.8h1.2l3.9,6.3v-6.3
+	h1V23.7z M25.3,16.9h-2.6v6.8h-1.1v-6.8H19V16h6.3V16.9z M32.8,20.3c0,1-0.1,1.7-0.4,2.2c-0.5,0.9-1.4,1.4-2.7,1.4s-2.2-0.5-2.7-1.4
+	c-0.3-0.5-0.4-1.2-0.4-2.2v-4.4h1.1v4.8c0,0.6,0.1,1,0.3,1.4c0.3,0.6,0.8,0.8,1.6,0.8c0.9,0,1.5-0.3,1.8-0.9
+	c0.2-0.3,0.3-0.8,0.3-1.3v-4.8h1.1L32.8,20.3L32.8,20.3z"/>
+</svg>


### PR DESCRIPTION
What's changing?
In order to showcase LocationManager in the new Intuit Open Source site, we need a standard for the naming and location of the project's logo, "os-project-logo.svg" to be located in the root directory and used if possibe in the readme file for branding alignment. A small version of the logo was created to be displayed on the OS Site (Content and visual designers were already in contact with Lucien)

![image](https://user-images.githubusercontent.com/14279937/48794905-2d1bdc80-ecb0-11e8-9b9f-91761c349649.png)
