### PR TITLE
feat: added ability to specify the activity type if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: cocoapods
 xcode_workspace: LocationManager/LocationManager.xcworkspace
 xcode_scheme: LocationManagerExample
 xcode_sdk: iphonesimulator12.0
-osx_image: xcode9
+osx_image: xcode10
 podfile: LocationManager/Podfile
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: osx
 cache: cocoapods
 xcode_workspace: LocationManager/LocationManager.xcworkspace
 xcode_scheme: LocationManagerExample
-xcode_sdk: iphonesimulator11.0
+xcode_sdk: iphonesimulator12.0
 osx_image: xcode9
 podfile: LocationManager/Podfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - gem install cocoapods
   - pod repo update
   
-script: set -o pipefail && xcodebuild test -workspace LocationManager/LocationManager.xcworkspace -scheme LocationManagerExample -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=11.0'
+script: set -o pipefail && xcodebuild test -workspace LocationManager/LocationManager.xcworkspace -scheme LocationManagerExample -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=12.0'
 
 after_success: 
     slather

--- a/LocationManager/INTULocationManager/INTULocationManager.h
+++ b/LocationManager/INTULocationManager/INTULocationManager.h
@@ -55,12 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Asynchronously requests the current location of the device using location services.
- 
+
  @param desiredAccuracy The accuracy level desired (refers to the accuracy and recency of the location).
- @param timeout         The maximum amount of time (in seconds) to wait for a location with the desired accuracy before completing. If 
+ @param timeout         The maximum amount of time (in seconds) to wait for a location with the desired accuracy before completing. If
                         this value is 0.0, no timeout will be set (will wait indefinitely for success, unless request is force completed or canceled).
  @param block           The block to execute upon success, failure, or timeout.
- 
+
  @return The location request ID, which can be used to force early completion or cancel the request while it is in progress.
  */
 - (INTULocationRequestID)requestLocationWithDesiredAccuracy:(INTULocationAccuracy)desiredAccuracy
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Asynchronously requests the current location of the device using location services, optionally delaying the timeout countdown until the user has
  responded to the dialog requesting permission for this app to access location services.
- 
+
  @param desiredAccuracy      The accuracy level desired (refers to the accuracy and recency of the location).
  @param timeout              The maximum amount of time (in seconds) to wait for a location with the desired accuracy before completing. If
                              this value is 0.0, no timeout will be set (will wait indefinitely for success, unless request is force completed or canceled).
@@ -82,6 +82,27 @@ NS_ASSUME_NONNULL_BEGIN
  @return The location request ID, which can be used to force early completion or cancel the request while it is in progress.
  */
 - (INTULocationRequestID)requestLocationWithDesiredAccuracy:(INTULocationAccuracy)desiredAccuracy
+                                                    timeout:(NSTimeInterval)timeout
+                                       delayUntilAuthorized:(BOOL)delayUntilAuthorized
+                                                      block:(INTULocationRequestBlock)block;
+
+/**
+ Asynchronously requests the current location of the device using location services, optionally delaying the timeout countdown until the user has
+ responded to the dialog requesting permission for this app to access location services.
+ 
+ @param desiredAccuracy      The accuracy level desired (refers to the accuracy and recency of the location).
+ @param desiredActivityType  The activity type desired, which controls when/if pausing occurs.
+ @param timeout              The maximum amount of time (in seconds) to wait for a location with the desired accuracy before completing. If
+                             this value is 0.0, no timeout will be set (will wait indefinitely for success, unless request is force completed or canceled).
+ @param delayUntilAuthorized A flag specifying whether the timeout should only take effect after the user responds to the system prompt requesting
+                             permission for this app to access location services. If YES, the timeout countdown will not begin until after the
+                             app receives location services permissions. If NO, the timeout countdown begins immediately when calling this method.
+ @param block                The block to execute upon success, failure, or timeout.
+ 
+ @return The location request ID, which can be used to force early completion or cancel the request while it is in progress.
+ */
+- (INTULocationRequestID)requestLocationWithDesiredAccuracy:(INTULocationAccuracy)desiredAccuracy
+                                        desiredActivityType:(CLActivityType)desiredActivityType
                                                     timeout:(NSTimeInterval)timeout
                                        delayUntilAuthorized:(BOOL)delayUntilAuthorized
                                                       block:(INTULocationRequestBlock)block;
@@ -102,15 +123,32 @@ NS_ASSUME_NONNULL_BEGIN
  Creates a subscription for location updates that will execute the block once per update indefinitely (until canceled), regardless of the accuracy of each location.
  The specified desired accuracy is passed along to location services, and controls how much power is used, with higher accuracies using more power.
  If an error occurs, the block will execute with a status other than INTULocationStatusSuccess, and the subscription will be canceled automatically.
- 
+
  @param desiredAccuracy The accuracy level desired, which controls how much power is used by the device's location services.
  @param block           The block to execute every time an updated location is available. Note that this block runs for every update, regardless of
                         whether the achievedAccuracy is at least the desiredAccuracy.
                         The status will be INTULocationStatusSuccess unless an error occurred; it will never be INTULocationStatusTimedOut.
+
+ @return The location request ID, which can be used to cancel the subscription of location updates to this block.
+ */
+- (INTULocationRequestID)subscribeToLocationUpdatesWithDesiredAccuracy:(INTULocationAccuracy)desiredAccuracy
+                                                                 block:(INTULocationRequestBlock)block;
+
+/**
+ Creates a subscription for location updates that will execute the block once per update indefinitely (until canceled), regardless of the accuracy of each location.
+ The specified desired accuracy is passed along to location services, and controls how much power is used, with higher accuracies using more power.
+ If an error occurs, the block will execute with a status other than INTULocationStatusSuccess, and the subscription will be canceled automatically.
+ 
+ @param desiredAccuracy     The accuracy level desired, which controls how much power is used by the device's location services.
+ @param desiredActivityType The activity type desired, which controls when/if pausing occurs.
+ @param block               The block to execute every time an updated location is available. Note that this block runs for every update, regardless of
+                            whether the achievedAccuracy is at least the desiredAccuracy.
+                            The status will be INTULocationStatusSuccess unless an error occurred; it will never be INTULocationStatusTimedOut.
  
  @return The location request ID, which can be used to cancel the subscription of location updates to this block.
  */
 - (INTULocationRequestID)subscribeToLocationUpdatesWithDesiredAccuracy:(INTULocationAccuracy)desiredAccuracy
+                                                   desiredActivityType:(CLActivityType)desiredActivityType
                                                                  block:(INTULocationRequestBlock)block;
 
 /**

--- a/LocationManager/INTULocationManager/INTULocationManager.m
+++ b/LocationManager/INTULocationManager/INTULocationManager.m
@@ -93,7 +93,7 @@ static id _sharedInstance;
     else if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusRestricted) {
         return INTULocationServicesStateRestricted;
     }
-    
+
     return INTULocationServicesStateAvailable;
 }
 
@@ -129,7 +129,7 @@ static id _sharedInstance;
         _locationManager = [[CLLocationManager alloc] init];
         _locationManager.delegate = self;
         self.preferredAuthorizationType = INTUAuthorizationTypeAuto;
-        
+
 #ifdef __IPHONE_8_4
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_8_4
         /* iOS 9 requires setting allowsBackgroundLocationUpdates to YES in order to receive background location updates.
@@ -254,26 +254,26 @@ static id _sharedInstance;
                                                       block:(INTULocationRequestBlock)block
 {
     NSAssert([NSThread isMainThread], @"INTULocationManager should only be called from the main thread.");
-    
+
     if (desiredAccuracy == INTULocationAccuracyNone) {
         NSAssert(desiredAccuracy != INTULocationAccuracyNone, @"INTULocationAccuracyNone is not a valid desired accuracy.");
         desiredAccuracy = INTULocationAccuracyCity; // default to the lowest valid desired accuracy
     }
-    
+
     INTULocationRequest *locationRequest = [[INTULocationRequest alloc] initWithType:INTULocationRequestTypeSingle];
     locationRequest.delegate = self;
     locationRequest.desiredAccuracy = desiredAccuracy;
     locationRequest.timeout = timeout;
     locationRequest.block = block;
     locationRequest.desiredActivityType = desiredActivityType;
-    
+
     BOOL deferTimeout = delayUntilAuthorized && ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined);
     if (!deferTimeout) {
         [locationRequest startTimeoutTimerIfNeeded];
     }
-    
+
     [self addLocationRequest:locationRequest];
-    
+
     return locationRequest.requestID;
 }
 
@@ -333,14 +333,14 @@ static id _sharedInstance;
                                                                  block:(INTULocationRequestBlock)block
 {
     NSAssert([NSThread isMainThread], @"INTULocationManager should only be called from the main thread.");
-    
+
     INTULocationRequest *locationRequest = [[INTULocationRequest alloc] initWithType:INTULocationRequestTypeSubscription];
     locationRequest.desiredAccuracy = desiredAccuracy;
     locationRequest.desiredActivityType = desiredActivityType;
     locationRequest.block = block;
-    
+
     [self addLocationRequest:locationRequest];
-    
+
     return locationRequest.requestID;
 }
 
@@ -356,12 +356,12 @@ static id _sharedInstance;
 - (INTULocationRequestID)subscribeToSignificantLocationChangesWithBlock:(INTULocationRequestBlock)block
 {
     NSAssert([NSThread isMainThread], @"INTULocationManager should only be called from the main thread.");
-    
+
     INTULocationRequest *locationRequest = [[INTULocationRequest alloc] initWithType:INTULocationRequestTypeSignificantChanges];
     locationRequest.block = block;
-    
+
     [self addLocationRequest:locationRequest];
-    
+
     return locationRequest.requestID;
 }
 
@@ -372,7 +372,7 @@ static id _sharedInstance;
 - (void)forceCompleteLocationRequest:(INTULocationRequestID)requestID
 {
     NSAssert([NSThread isMainThread], @"INTULocationManager should only be called from the main thread.");
-    
+
     for (INTULocationRequest *locationRequest in self.locationRequests) {
         if (locationRequest.requestID == requestID) {
             if (locationRequest.isRecurring) {
@@ -393,7 +393,7 @@ static id _sharedInstance;
 - (void)cancelLocationRequest:(INTULocationRequestID)requestID
 {
     NSAssert([NSThread isMainThread], @"INTULocationManager should only be called from the main thread.");
-    
+
     for (INTULocationRequest *locationRequest in self.locationRequests) {
         if (locationRequest.requestID == requestID) {
             [locationRequest cancel];
@@ -453,7 +453,7 @@ static id _sharedInstance;
         [self completeLocationRequest:locationRequest];
         return;
     }
-    
+
     switch (locationRequest.type) {
         case INTULocationRequestTypeSingle:
         case INTULocationRequestTypeSubscription:
@@ -481,7 +481,7 @@ static id _sharedInstance;
     [newLocationRequests addObject:locationRequest];
     self.locationRequests = newLocationRequests;
     INTULMLog(@"Location Request added with ID: %ld", (long)locationRequest.requestID);
-    
+
     // Process all location requests now, as we may be able to immediately complete the request just added above
     // if a location update was recently received (stored in self.currentLocation) that satisfies its criteria.
     [self processLocationRequests];
@@ -495,7 +495,7 @@ static id _sharedInstance;
     __INTU_GENERICS(NSMutableArray, INTULocationRequest *) *newLocationRequests = [NSMutableArray arrayWithArray:self.locationRequests];
     [newLocationRequests removeObject:locationRequest];
     self.locationRequests = newLocationRequests;
-    
+
     switch (locationRequest.type) {
         case INTULocationRequestTypeSingle:
         case INTULocationRequestTypeSubscription:
@@ -508,7 +508,7 @@ static id _sharedInstance;
                 }
             }
             [self updateWithMaximumDesiredAccuracy:maximumDesiredAccuracy];
-            
+
             [self stopUpdatingLocationIfPossible];
         }
             break;
@@ -522,7 +522,7 @@ static id _sharedInstance;
  Returns the most recent current location, or nil if the current location is unknown, invalid, or stale.
  */
 - (CLLocation *)currentLocation
-{    
+{
     if (_currentLocation) {
         // Location isn't nil, so test to see if it is valid
         if (!CLLocationCoordinate2DIsValid(_currentLocation.coordinate) || (_currentLocation.coordinate.latitude == 0.0 && _currentLocation.coordinate.longitude == 0.0)) {
@@ -530,7 +530,7 @@ static id _sharedInstance;
             _currentLocation = nil;
         }
     }
-    
+
     // Location is either nil or valid at this point, return it
     return _currentLocation;
 }
@@ -544,7 +544,7 @@ static id _sharedInstance;
     // As of iOS 8, apps must explicitly request location services permissions. INTULocationManager supports both levels, "Always" and "When In Use".
     // INTULocationManager determines which level of permissions to request based on which description key is present in your app's Info.plist
     // If you provide values for both description keys, the more permissive "Always" level is requested.
-    
+
     double iOSVersion = floor(NSFoundationVersionNumber);
     BOOL isiOSVersion7to10 = iOSVersion > NSFoundationVersionNumber_iOS_7_1 && iOSVersion <= NSFoundationVersionNumber10_11_Max;
     if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined) {
@@ -570,7 +570,7 @@ static id _sharedInstance;
             case INTUAuthorizationTypeWhenInUse:
                 needRequestWhenInUse = canRequestWhenInUse;
                 break;
-                
+
             default:
                 break;
         }
@@ -642,28 +642,20 @@ static id _sharedInstance;
 {
     switch (desiredActivityType) {
         case CLActivityTypeFitness:
-            if (self.locationManager.activityType != CLActivityTypeFitness) {
-                self.locationManager.activityType = CLActivityTypeFitness;
-                INTULMLog(@"Changing location services activity type to: fitness.");
-            }
+            self.locationManager.activityType = CLActivityTypeFitness;
+            INTULMLog(@"Changing location services activity type to: fitness.");
             break;
         case CLActivityTypeAutomotiveNavigation:
-            if (self.locationManager.activityType != CLActivityTypeAutomotiveNavigation) {
-                self.locationManager.activityType = CLActivityTypeAutomotiveNavigation;
-                INTULMLog(@"Changing location services activity type to: automotive navigation.");
-            }
+            self.locationManager.activityType = CLActivityTypeAutomotiveNavigation;
+            INTULMLog(@"Changing location services activity type to: automotive navigation.");
             break;
         case CLActivityTypeAirborne:
-            if (self.locationManager.activityType != CLActivityTypeAirborne) {
-                self.locationManager.activityType = CLActivityTypeAirborne;
-                INTULMLog(@"Changing location services activity type to: airborne.");
-            }
+            self.locationManager.activityType = CLActivityTypeAirborne;
+            INTULMLog(@"Changing location services activity type to: airborne.");
             break;
         case CLActivityTypeOtherNavigation:
-            if (self.locationManager.activityType != CLActivityTypeOtherNavigation) {
-                self.locationManager.activityType = CLActivityTypeOtherNavigation;
-                INTULMLog(@"Changing location services activity type to: other navigation.");
-            }
+            self.locationManager.activityType = CLActivityTypeOtherNavigation;
+            INTULMLog(@"Changing location services activity type to: other navigation.");
             break;
         case CLActivityTypeOther:
         default:
@@ -678,7 +670,7 @@ static id _sharedInstance;
 - (void)startMonitoringSignificantLocationChangesIfNeeded
 {
     [self requestAuthorizationIfNeeded];
-    
+
     NSArray *locationRequests = [self activeLocationRequestsWithType:INTULocationRequestTypeSignificantChanges];
     if (locationRequests.count == 0) {
         [self.locationManager startMonitoringSignificantLocationChanges];
@@ -695,7 +687,7 @@ static id _sharedInstance;
 - (void)startUpdatingLocationIfNeeded
 {
     [self requestAuthorizationIfNeeded];
-    
+
     NSArray *locationRequests = [self activeLocationRequestsExcludingType:INTULocationRequestTypeSignificantChanges];
     if (locationRequests.count == 0) {
         [self.locationManager startUpdatingLocation];
@@ -741,14 +733,14 @@ static id _sharedInstance;
 - (void)processLocationRequests
 {
     CLLocation *mostRecentLocation = self.currentLocation;
-    
+
     for (INTULocationRequest *locationRequest in self.locationRequests) {
         if (locationRequest.hasTimedOut) {
             // Non-recurring request has timed out, complete it
             [self completeLocationRequest:locationRequest];
             continue;
         }
-        
+
         if (mostRecentLocation != nil) {
             if (locationRequest.isRecurring) {
                 // This is a subscription request, which lives indefinitely (unless manually canceled) and receives every location update we get
@@ -793,14 +785,14 @@ static id _sharedInstance;
     if (locationRequest == nil) {
         return;
     }
-    
+
     [locationRequest complete];
     [self removeLocationRequest:locationRequest];
-    
+
     INTULocationStatus status = [self statusForLocationRequest:locationRequest];
     CLLocation *currentLocation = self.currentLocation;
     INTULocationAccuracy achievedAccuracy = [self achievedAccuracyForLocation:currentLocation];
-    
+
     // INTULocationManager is not thread safe and should only be called from the main thread, so we should already be executing on the main thread now.
     // dispatch_async is used to ensure that the completion block for a request is not executed before the request ID is returned, for example in the
     // case where the user has denied permission to access location services and the request is immediately completed with the appropriate error.
@@ -809,7 +801,7 @@ static id _sharedInstance;
             locationRequest.block(currentLocation, achievedAccuracy, status);
         }
     });
-    
+
     INTULMLog(@"Location Request completed with ID: %ld, currentLocation: %@, achievedAccuracy: %lu, status: %lu", (long)locationRequest.requestID, currentLocation, (unsigned long) achievedAccuracy, (unsigned long)status);
 }
 
@@ -819,11 +811,11 @@ static id _sharedInstance;
 - (void)processRecurringRequest:(INTULocationRequest *)locationRequest
 {
     NSAssert(locationRequest.isRecurring, @"This method should only be called for recurring location requests.");
-    
+
     INTULocationStatus status = [self statusForLocationRequest:locationRequest];
     CLLocation *currentLocation = self.currentLocation;
     INTULocationAccuracy achievedAccuracy = [self achievedAccuracyForLocation:currentLocation];
-    
+
     // INTULocationManager is not thread safe and should only be called from the main thread, so we should already be executing on the main thread now.
     // dispatch_async is used to ensure that the completion block for a request is not executed before the request ID is returned.
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -859,7 +851,7 @@ static id _sharedInstance;
 - (INTULocationStatus)statusForLocationRequest:(INTULocationRequest *)locationRequest
 {
     INTULocationServicesState locationServicesState = [INTULocationManager locationServicesState];
-    
+
     if (locationServicesState == INTULocationServicesStateDisabled) {
         return INTULocationStatusServicesDisabled;
     }
@@ -878,7 +870,7 @@ static id _sharedInstance;
     else if (locationRequest.hasTimedOut) {
         return INTULocationStatusTimedOut;
     }
-    
+
     return INTULocationStatusSuccess;
 }
 
@@ -891,10 +883,10 @@ static id _sharedInstance;
     if (!location) {
         return INTULocationAccuracyNone;
     }
-    
+
     NSTimeInterval timeSinceUpdate = fabs([location.timestamp timeIntervalSinceNow]);
     CLLocationAccuracy horizontalAccuracy = location.horizontalAccuracy;
-    
+
     if (horizontalAccuracy <= kINTUHorizontalAccuracyThresholdRoom &&
         timeSinceUpdate <= kINTUUpdateTimeStaleThresholdRoom) {
         return INTULocationAccuracyRoom;
@@ -1090,10 +1082,10 @@ BOOL INTUCLHeadingIsIsValid(CLHeading *heading)
 {
     // Received update successfully, so clear any previous errors
     self.updateFailed = NO;
-    
+
     CLLocation *mostRecentLocation = [locations lastObject];
     self.currentLocation = mostRecentLocation;
-    
+
     // Process the location requests using the updated location
     [self processLocationRequests];
 }
@@ -1155,7 +1147,7 @@ BOOL INTUCLHeadingIsIsValid(CLHeading *heading)
         _locationManager.showsBackgroundLocationIndicator = shows;
     }
 }
-    
+
 - (void)setPausesLocationUpdatesAutomatically:(BOOL) pauses
 {
     _locationManager.pausesLocationUpdatesAutomatically = pauses;

--- a/LocationManager/INTULocationManager/INTULocationRequest.h
+++ b/LocationManager/INTULocationManager/INTULocationRequest.h
@@ -69,6 +69,8 @@ typedef NS_ENUM(NSInteger, INTULocationRequestType) {
 @property (nonatomic, readonly) BOOL isRecurring;
 /** The desired accuracy for this location request. */
 @property (nonatomic, assign) INTULocationAccuracy desiredAccuracy;
+/** The desired activity type for this location request. */
+@property (nonatomic, assign) CLActivityType desiredActivityType;
 /** The maximum amount of time the location request should be allowed to live before completing.
     If this value is exactly 0.0, it will be ignored (the request will never timeout by itself). */
 @property (nonatomic, assign) NSTimeInterval timeout;

--- a/LocationManager/LocationManager.xcodeproj/xcshareddata/xcschemes/INTULocationManager.xcscheme
+++ b/LocationManager/LocationManager.xcodeproj/xcshareddata/xcschemes/INTULocationManager.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6681CD271B1306C30080DBA9"
-               BuildableName = "INTULocationManager.framework"
-               BlueprintName = "INTULocationManager"
+               BlueprintIdentifier = "B116683E18E5CEDD00D1E022"
+               BuildableName = "LocationManagerExample.app"
+               BlueprintName = "LocationManagerExample"
                ReferencedContainer = "container:LocationManager.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -75,6 +75,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B116683E18E5CEDD00D1E022"
+            BuildableName = "LocationManagerExample.app"
+            BlueprintName = "LocationManagerExample"
+            ReferencedContainer = "container:LocationManager.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -86,6 +95,10 @@
       </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/LocationManager/LocationManagerExample/Base.lproj/Main.storyboard
+++ b/LocationManager/LocationManagerExample/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
-    <device id="retina5_5" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="to5-xT-e4q">
-                                <rect key="frame" x="76" y="601" width="263" height="33"/>
+                                <rect key="frame" x="76" y="601" width="262" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="33" id="eeH-ld-a4X"/>
                                 </constraints>
@@ -35,7 +33,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xfW-ll-n06">
-                                <rect key="frame" x="76" y="683" width="263" height="33"/>
+                                <rect key="frame" x="76" y="683" width="262" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="33" id="KcS-55-8iu"/>
                                 </constraints>
@@ -48,14 +46,14 @@
                                 </connections>
                             </button>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Status Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2Q-5P-iwC">
-                                <rect key="frame" x="20" y="25" width="374" height="301"/>
+                                <rect key="frame" x="20" y="5" width="374" height="221"/>
                                 <color key="backgroundColor" red="0.93731731176376343" green="0.93728923797607422" blue="0.93730515241622925" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="jqv-Yh-c90">
-                                <rect key="frame" x="50" y="488" width="314" height="29"/>
+                                <rect key="frame" x="37.666666666666657" y="388" width="339" height="29"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="28" id="CiS-Ui-5eS"/>
                                 </constraints>
@@ -70,8 +68,24 @@
                                     <action selector="desiredAccuracyControlChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="HLd-94-Htx"/>
                                 </connections>
                             </segmentedControl>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ujK-C3-t78">
+                                <rect key="frame" x="38" y="464" width="339" height="29"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="28" id="0Cw-PF-fv5"/>
+                                </constraints>
+                                <segments>
+                                    <segment title="Air"/>
+                                    <segment title="Auto"/>
+                                    <segment title="Fitness"/>
+                                    <segment title="Other Nav"/>
+                                    <segment title="Other"/>
+                                </segments>
+                                <connections>
+                                    <action selector="desiredActivityControlChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="RUC-ky-fed"/>
+                                </connections>
+                            </segmentedControl>
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="10" minValue="0.0" maxValue="30" translatesAutoresizingMaskIntoConstraints="NO" id="90N-7e-lcl">
-                                <rect key="frame" x="74" y="561" width="267" height="31"/>
+                                <rect key="frame" x="74" y="561" width="266" height="31"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="VJD-Ii-MB3"/>
                                 </constraints>
@@ -80,7 +94,7 @@
                                 </connections>
                             </slider>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location Timeout: 10 seconds" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5cW-3f-eSH">
-                                <rect key="frame" x="93" y="533" width="229" height="20"/>
+                                <rect key="frame" x="92.666666666666686" y="533" width="229" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="HrR-gG-zyD"/>
                                 </constraints>
@@ -89,7 +103,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gUW-qc-5N5">
-                                <rect key="frame" x="76" y="642" width="263" height="33"/>
+                                <rect key="frame" x="76" y="642" width="262" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="33" id="lRi-aH-ZI8"/>
                                 </constraints>
@@ -102,48 +116,54 @@
                                 </connections>
                             </button>
                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="pss-9E-RE2">
-                                <rect key="frame" x="31" y="599.66666666666663" width="37" height="37"/>
+                                <rect key="frame" x="31" y="599" width="37" height="37"/>
                                 <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </activityIndicatorView>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Desired location accuracy" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DyX-J3-zOE">
-                                <rect key="frame" x="108" y="457" width="198" height="21"/>
+                                <rect key="frame" x="108" y="357" width="198" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="yn8-hb-yfF">
-                                <rect key="frame" x="41.666666666666671" y="335" width="51.000000000000014" height="31"/>
+                                <rect key="frame" x="42" y="235" width="51" height="31"/>
                                 <connections>
                                     <action selector="subscriptionSwitchChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="CdW-6L-0tT"/>
                                 </connections>
                             </switch>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subscribe to location updates" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3kq-sd-gQP">
-                                <rect key="frame" x="99" y="341" width="216" height="19"/>
+                                <rect key="frame" x="99" y="241" width="216" height="19"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="RyL-36-ou2">
-                                <rect key="frame" x="41.666666666666671" y="374" width="51.000000000000014" height="31"/>
+                                <rect key="frame" x="42" y="274" width="51" height="31"/>
                                 <connections>
                                     <action selector="subscriptionSwitchChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="yic-df-Pgt"/>
                                 </connections>
                             </switch>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subscribe to significant changes" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zQs-Jw-ocJ">
-                                <rect key="frame" x="99" y="378" width="236.66666666666669" height="23"/>
+                                <rect key="frame" x="98.999999999999986" y="278" width="236.66666666666663" height="23"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="lGa-XX-TS0">
-                                <rect key="frame" x="41.666666666666671" y="413" width="51.000000000000014" height="31"/>
+                                <rect key="frame" x="42" y="313" width="51" height="31"/>
                                 <connections>
                                     <action selector="headingSubscriptionSwitchChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="T6N-Sf-lcE"/>
                                 </connections>
                             </switch>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subscribe to heading updates" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wzB-D5-V0v">
-                                <rect key="frame" x="99" y="419" width="236.66666666666669" height="19"/>
+                                <rect key="frame" x="98.999999999999986" y="319" width="236.66666666666663" height="19"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Desired activity type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IIy-ut-Cpi">
+                                <rect key="frame" x="128.66666666666666" y="432" width="156.99999999999997" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -151,11 +171,12 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="RyL-36-ou2" firstAttribute="leading" secondItem="lGa-XX-TS0" secondAttribute="leading" id="0nc-Ge-CIZ"/>
-                            <constraint firstItem="5cW-3f-eSH" firstAttribute="top" secondItem="jqv-Yh-c90" secondAttribute="bottom" constant="17" id="0sy-yo-oWS"/>
+                            <constraint firstItem="5cW-3f-eSH" firstAttribute="top" secondItem="jqv-Yh-c90" secondAttribute="bottom" constant="117" id="0sy-yo-oWS"/>
                             <constraint firstItem="J2Q-5P-iwC" firstAttribute="top" secondItem="1MX-v3-rhk" secondAttribute="bottom" constant="5" id="1oY-hz-5Aq"/>
                             <constraint firstItem="to5-xT-e4q" firstAttribute="leading" secondItem="gUW-qc-5N5" secondAttribute="leading" id="6xM-Ab-vgl"/>
                             <constraint firstItem="gUW-qc-5N5" firstAttribute="trailing" secondItem="xfW-ll-n06" secondAttribute="trailing" id="6yE-ez-Nch"/>
                             <constraint firstItem="3kq-sd-gQP" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="73f-6S-798"/>
+                            <constraint firstItem="ujK-C3-t78" firstAttribute="top" secondItem="IIy-ut-Cpi" secondAttribute="bottom" constant="11" id="7SL-C6-UNg"/>
                             <constraint firstItem="yn8-hb-yfF" firstAttribute="leading" secondItem="RyL-36-ou2" secondAttribute="leading" id="Bie-ph-zd1"/>
                             <constraint firstAttribute="leadingMargin" secondItem="J2Q-5P-iwC" secondAttribute="leading" id="JHL-xq-oWS"/>
                             <constraint firstItem="pss-9E-RE2" firstAttribute="centerY" secondItem="to5-xT-e4q" secondAttribute="centerY" id="KvI-Mb-RvP"/>
@@ -171,20 +192,24 @@
                             <constraint firstItem="3kq-sd-gQP" firstAttribute="leading" secondItem="yn8-hb-yfF" secondAttribute="trailing" constant="8" symbolic="YES" id="Xbp-k1-Ael"/>
                             <constraint firstItem="to5-xT-e4q" firstAttribute="trailing" secondItem="gUW-qc-5N5" secondAttribute="trailing" id="Z5E-es-mTg"/>
                             <constraint firstItem="to5-xT-e4q" firstAttribute="top" secondItem="90N-7e-lcl" secondAttribute="bottom" constant="10" id="ZKa-xH-42u"/>
+                            <constraint firstItem="ujK-C3-t78" firstAttribute="trailing" secondItem="J2Q-5P-iwC" secondAttribute="trailing" constant="-17" id="ZSw-87-35t"/>
                             <constraint firstItem="gUW-qc-5N5" firstAttribute="leading" secondItem="xfW-ll-n06" secondAttribute="leading" id="azD-04-Gra"/>
                             <constraint firstItem="3kq-sd-gQP" firstAttribute="leading" secondItem="zQs-Jw-ocJ" secondAttribute="leading" id="brg-MF-yfN"/>
                             <constraint firstItem="to5-xT-e4q" firstAttribute="leading" secondItem="pss-9E-RE2" secondAttribute="trailing" constant="8" symbolic="YES" id="dhM-3S-LDQ"/>
                             <constraint firstItem="zQs-Jw-ocJ" firstAttribute="leading" secondItem="wzB-D5-V0v" secondAttribute="leading" id="dpC-oE-OK5"/>
                             <constraint firstAttribute="trailingMargin" secondItem="J2Q-5P-iwC" secondAttribute="trailing" id="egE-WO-Loj"/>
                             <constraint firstItem="zQs-Jw-ocJ" firstAttribute="top" secondItem="3kq-sd-gQP" secondAttribute="bottom" constant="18" id="esW-Ms-wBl"/>
+                            <constraint firstItem="5cW-3f-eSH" firstAttribute="top" secondItem="ujK-C3-t78" secondAttribute="bottom" constant="41" id="hFt-OG-hCi"/>
                             <constraint firstItem="lGa-XX-TS0" firstAttribute="centerY" secondItem="wzB-D5-V0v" secondAttribute="centerY" id="ixz-Jz-ne0"/>
                             <constraint firstItem="90N-7e-lcl" firstAttribute="leading" secondItem="to5-xT-e4q" secondAttribute="leading" id="lRP-OE-txa"/>
                             <constraint firstItem="5cW-3f-eSH" firstAttribute="centerX" secondItem="90N-7e-lcl" secondAttribute="centerX" id="lau-S8-ERw"/>
+                            <constraint firstItem="ujK-C3-t78" firstAttribute="leading" secondItem="J2Q-5P-iwC" secondAttribute="leading" constant="18" id="mnh-kH-YDm"/>
                             <constraint firstItem="zQs-Jw-ocJ" firstAttribute="trailing" secondItem="wzB-D5-V0v" secondAttribute="trailing" id="pEU-19-0xv"/>
                             <constraint firstItem="RyL-36-ou2" firstAttribute="centerY" secondItem="zQs-Jw-ocJ" secondAttribute="centerY" id="q2f-rJ-RbJ"/>
                             <constraint firstItem="DyX-J3-zOE" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="qPA-L4-pEO"/>
                             <constraint firstItem="DyX-J3-zOE" firstAttribute="centerX" secondItem="jqv-Yh-c90" secondAttribute="centerX" id="qtr-nz-O4g"/>
                             <constraint firstItem="yn8-hb-yfF" firstAttribute="centerY" secondItem="3kq-sd-gQP" secondAttribute="centerY" id="rpP-fR-Uyi"/>
+                            <constraint firstItem="ujK-C3-t78" firstAttribute="centerX" secondItem="IIy-ut-Cpi" secondAttribute="centerX" constant="0.33333333333337123" id="sXy-jp-FlN"/>
                             <constraint firstItem="xfW-ll-n06" firstAttribute="top" secondItem="gUW-qc-5N5" secondAttribute="bottom" constant="8" id="vdO-iy-Qw4"/>
                             <constraint firstItem="3kq-sd-gQP" firstAttribute="top" secondItem="J2Q-5P-iwC" secondAttribute="bottom" constant="15" id="vgu-tb-xbK"/>
                             <constraint firstItem="jqv-Yh-c90" firstAttribute="top" secondItem="DyX-J3-zOE" secondAttribute="bottom" constant="10" id="wpo-i5-fbq"/>
@@ -196,6 +221,8 @@
                         <outlet property="cancelRequestButton" destination="xfW-ll-n06" id="uyS-Rp-2gf"/>
                         <outlet property="desiredAccuracyControl" destination="jqv-Yh-c90" id="AYX-uO-JYR"/>
                         <outlet property="desiredAccuracyLabel" destination="DyX-J3-zOE" id="W4N-0t-ORz"/>
+                        <outlet property="desiredActivityLabel" destination="IIy-ut-Cpi" id="tsK-1A-zl3"/>
+                        <outlet property="desiredActivityTypeControl" destination="ujK-C3-t78" id="awk-7C-x1k"/>
                         <outlet property="forceCompleteRequestButton" destination="gUW-qc-5N5" id="cjK-h6-7Ir"/>
                         <outlet property="requestCurrentLocationButton" destination="to5-xT-e4q" id="2kr-d0-0aZ"/>
                         <outlet property="statusLabel" destination="J2Q-5P-iwC" id="HbW-Us-nDV"/>
@@ -207,11 +234,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="137.68115942028987" y="134.5108695652174"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina5_5.fullscreen"/>
-    </simulatedMetricsContainer>
 </document>

--- a/LocationManager/Podfile
+++ b/LocationManager/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '10.0'
+platform :ios, '12.0'
 
 target 'LocationManagerExample' do
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Starting with iOS 8, you **must** provide a description for how your app uses lo
 #### iOS 11
 Starting with iOS 11, you **must** provide a description for how your app uses location services by setting a string for the key `NSLocationAlwaysAndWhenInUseUsageDescription` in your app's `Info.plist` file.
 
+#### iOS 12
+Starting with iOS 12, you will have access to set the `desiredActivityType` as `CLActivityTypeAirborne`.
+
 ### Getting the Current Location (once)
 To get the device's current location, use the method `requestLocationWithDesiredAccuracy:timeout:block:`.
 
@@ -72,6 +75,15 @@ INTULocationAccuracyNeighborhood  // 1000 meters or better, received within the 
 INTULocationAccuracyBlock         // 100 meters or better, received within the last 1 minute
 INTULocationAccuracyHouse         // 15 meters or better, received within the last 15 seconds
 INTULocationAccuracyRoom          // 5 meters or better, received within the last 5 seconds      -- highest accuracy
+```
+
+The `desiredActivityType` parameter indicated the **type of activity** that is being tracked. The possible values are:
+```objective-c
+CLActivityTypeFitness               // Track fitness activities such as walking, running, cycling, and so on
+CLActivityTypeAutomotiveNavigation  // Track location changes to the automobile
+CLActivityTypeAirborne              // Track airborne activities - iOS 12 and above
+CLActivityTypeOtherNavigation       // Track vehicular navigation that are not automobile related
+CLActivityTypeOther                 // Track unknown activities. This is the default value
 ```
 
 The `timeout` parameter specifies how long you are willing to wait for a location with the accuracy you requested. The timeout guarantees that your block will execute within this period of time, either with a location of at least the accuracy you requested (`INTULocationStatusSuccess`), or with whatever location could be determined before the timeout interval was up (`INTULocationStatusTimedOut`). Pass `0.0` for no timeout *(not recommended)*.


### PR DESCRIPTION
The iOS activity types, CLActivityType, help the iOS determine what type of activity is being tracked and when/if the tracking should be paused based on how long the device has been stationary.

This PR allows the user to set the activity type for their specific use case. CLLocationManager defaults to CLActivityTypeOther and will continue to do so if not set by the user.

- overloaded subscription methods with new activity type parameter
- updated example app to include activity type selection
- updated read.me with info on activity type
- updated device simulator iOS version to 12
- updated travis Xcode version to 10
- updated target iOS pod version to 12