### PR TITLE
bug: `--no-ri --no-doc` are deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ xcode_sdk: iphonesimulator11.0
 osx_image: xcode9
 podfile: LocationManager/Podfile
 
-rvm:
-  - 2.2.2
-
 before_install:
   # - gem install cocoapods --no-ri --no-rdoc
   - gem install slather --no-document

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
 
 before_install:
   # - gem install cocoapods --no-ri --no-rdoc
-  - gem install slather --no-ri --no-rdoc
+  - gem install slather --no-document
   - gem install cocoapods
   - pod repo update
   


### PR DESCRIPTION
- changed `--no-ri --no-doc` to `--no-document` as the former is deprecated
- removed definition of `rvm` as it was referencing an old version